### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ npm install --save react-vnc-display
 The component from react-vnc-display is `VncDisplay`. This module can be required via ES imports, CommonJS require, or UMD.
 
 ```js
-import { VncDisplay } from 'react-vnc-display';
+import VncDisplay from 'react-vnc-display';
 
 // using require
-const { VncDisplay } = require('react-vnc-display');
+const VncDisplay = require('react-vnc-display');
 ```
 
 ### Usage
@@ -45,7 +45,7 @@ After importing the component, it can be rendered with the required `url` prop:
 ```jsx
 import React from 'react';
 import { render } from 'react-dom';
-import { VncDisplay } from 'react-vnc-display';
+import VncDisplay from 'react-vnc-display';
 
 render((
   <VncDisplay url="wss://some-remote-display:5991/path" />


### PR DESCRIPTION
The usage example code is incorrect.
If use it as the previous example, an error like the image below will occur.
```
import { VncDisplay } from 'react-vnc-display';
```
![image](https://user-images.githubusercontent.com/31546782/65364520-46cddd80-dc4d-11e9-8a14-df7df1601d86.png)

It should be modified as follows.
```
import VncDisplay from 'react-vnc-display';
```